### PR TITLE
Fix infinite redirect due to extra comma in buildModules

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -58,7 +58,7 @@ export default {
         ]
       }
     }],
-    ,['@vue-storefront/nuxt-theme'],
+    ['@vue-storefront/nuxt-theme'],
   ],
   modules: [
     ['nuxt-i18n', {


### PR DESCRIPTION
@nuxt/core@2.15.8/dist/core.js ModuleContainer addModule
checks if a module is not inside devModule. This check breaks
if the array contain an extra undefined value because if the
module is a string than the handler is undefined

Here is the code snippet from @nuxt/core:
```
    // Prevent adding buildModules-listed entries in production
    if (this.options.buildModules.includes(handler) && this.options._start) {
      return
    }
```